### PR TITLE
Feature/single site multi sitemap

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Properties for nuget package.
         See full list of supported MSBuild properties for 'dotnet pack': https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
     -->
-    <VersionPrefix>1.0</VersionPrefix>
+    <VersionPrefix>1.1</VersionPrefix>
     <Description>Embedded Sitemap Service (briefly and formerly known as Embedded Site Discovery Service) is an integration for Optimizely developers and digital marketers looking to maximize search engine visibility with minimal effort. Whether you're managing a single site or multiple sites, SDS ensures your content is always discoverable. The integration can also generate product feeds, making it a versatile tool for e-commerce sites.</Description>
     <PackageProjectUrl>https://github.com/delawarePro/dlw-optimizely-sds</PackageProjectUrl>
     <PackageReleaseNotes>Initial release of Embedded Sitemap Service for Optimizely. Note: everything has been renamed from SDS/Sds to Sitemap, including .dll files and namespaces.</PackageReleaseNotes>

--- a/src/Delaware.Optimizely.Sitemap.Core/BuilderExtensions.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/BuilderExtensions.cs
@@ -68,7 +68,7 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="siteDefinition">The site to add a catalog for.</param>
-    /// <param name="languages">The languages the sitemap will have to be published in for this site.</param>
+    /// <param name="languages">*All* languages the sitemap will have to be published in for this site.</param>
     /// <param name="configure"></param>
     public static IServiceProvider AddSitemapCatalog(
         this IServiceProvider serviceProvider,
@@ -78,7 +78,7 @@ public static class BuilderExtensions
     {
         var siteCatalogDirectory = serviceProvider.GetRequiredService<SiteCatalogDirectory>();
 
-        siteCatalogDirectory.AddSiteCatalog(siteDefinition, configure);
+        siteCatalogDirectory.AddSiteCatalog(siteDefinition, configure, languages);
 
         return serviceProvider;
     }

--- a/src/Delaware.Optimizely.Sitemap.Core/BuilderExtensions.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/BuilderExtensions.cs
@@ -68,7 +68,7 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="siteDefinition">The site to add a catalog for.</param>
-    /// <param name="languages">*All* languages the sitemap will have to be published in for this site.</param>
+    /// <param name="languages">*All* languages to include in sitemap for this site.</param>
     /// <param name="configure"></param>
     public static IServiceProvider AddSitemapCatalog(
         this IServiceProvider serviceProvider,

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
@@ -12,12 +12,16 @@ namespace Delaware.Optimizely.Sitemap.Core.Builders;
 
 public class DefaultSiteCatalogBuilder(IServiceProvider serviceProvider, SiteDefinition siteDefinition) : ISiteCatalogBuilder
 {
+    public const string DefaultLanguageGroupName = "Default";
+
     private readonly IList<ISiteCatalogFilter> _pageFilters = new List<ISiteCatalogFilter>();
     private readonly IList<ISiteCatalogFilter> _blockFilters = new List<ISiteCatalogFilter>();
     private readonly IList<ISiteCatalogBlockProvider> _blockReferencesProviders = new List<ISiteCatalogBlockProvider>();
 
     private ISiteCatalogPageProvider? PageProvider { get; set; }
     private ISiteCatalogEntryMapper? DefaultEntryMapper { get; set; }
+
+    private readonly IDictionary<string, IReadOnlyCollection<string>> _languageGroups = new Dictionary<string, IReadOnlyCollection<string>>();
 
     public void WithDefaults()
     {
@@ -134,11 +138,27 @@ public class DefaultSiteCatalogBuilder(IServiceProvider serviceProvider, SiteDef
         return this;
     }
 
+    public ISiteCatalogBuilder WithLanguageGroup(IReadOnlyCollection<string> languages, string name = DefaultLanguageGroupName)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Specify a language group name.", nameof(name));
+    
+        if(_languageGroups.ContainsKey(name))
+            throw new Exception($"A language group with the name '{name}' already exists.");
+
+        _languageGroups[name] = languages.ToArray();
+
+        return this;
+    }
+
     public ISiteCatalog Build()
     {
         var pageProvider = PageProvider ?? throw new NullReferenceException($"No page provider registered for '{siteDefinition.Name}' site catalog.");
         var defaultMapper = DefaultEntryMapper ?? throw new NullReferenceException($"No default mapping provided for '{siteDefinition.Name}' site catalog.");
 
-        return new SiteCatalog(siteDefinition, pageProvider, defaultMapper, _pageFilters, _blockFilters, _blockReferencesProviders);
+        return new SiteCatalog(siteDefinition, pageProvider, defaultMapper, _pageFilters, _blockFilters, _blockReferencesProviders)
+        {
+            LanguageGroups = _languageGroups
+        };
     }
 }

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
@@ -191,16 +191,10 @@ public class DefaultSiteCatalogBuilder(
             throw new ArgumentException($"Specify one or more languages for site catalog {siteDefinition.Name}.");
         }
 
-        var lg = DetermineLanguageGroups(languages, _languageGroups);
         // If there are language groups configured, use those.
         // Otherwise, create a 'Default' language group containing all languages for site.
-        var languageGroups = _languageGroups.Any()
-            ? _languageGroups
-            : new List<SitemapLanguageGroup>
-            {
-                new(new SitemapLanguageGroupKey(DefaultLanguageGroupName), languages ?? [])
-            };
-
+        var languageGroups = DetermineLanguageGroups(languages, _languageGroups);
+        
         return new SiteCatalog(siteDefinition, pageProvider, defaultMapper, _pageFilters, _blockFilters, _blockReferencesProviders)
         {
             LanguageGroups = (IReadOnlyCollection<SitemapLanguageGroup>)languageGroups

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
@@ -6,6 +6,7 @@ using Delaware.Optimizely.Sitemap.Shared.Models;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.Core.Routing.Internal;
+using EPiServer.Data.Entity;
 using EPiServer.Web;
 using EPiServer.Web.Mvc.Html.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -185,6 +186,12 @@ public class DefaultSiteCatalogBuilder(
         var pageProvider = PageProvider ?? throw new NullReferenceException($"No page provider registered for '{siteDefinition.Name}' site catalog.");
         var defaultMapper = DefaultEntryMapper ?? throw new NullReferenceException($"No default mapping provided for '{siteDefinition.Name}' site catalog.");
 
+        if (languages == null || !languages.Any())
+        {
+            throw new ArgumentException($"Specify one or more languages for site catalog {siteDefinition.Name}.");
+        }
+
+        var lg = DetermineLanguageGroups(languages, _languageGroups);
         // If there are language groups configured, use those.
         // Otherwise, create a 'Default' language group containing all languages for site.
         var languageGroups = _languageGroups.Any()
@@ -198,5 +205,77 @@ public class DefaultSiteCatalogBuilder(
         {
             LanguageGroups = (IReadOnlyCollection<SitemapLanguageGroup>)languageGroups
         };
+    }
+
+    private static IList<SitemapLanguageGroup> DetermineLanguageGroups(string[] languages,
+        IList<SitemapLanguageGroup> languageGroups)
+    {
+        if (!languageGroups.Any())
+        {
+            return new List<SitemapLanguageGroup> { new(DefaultLanguageGroupName, languages) };
+        }
+
+        var siteLanguages = new HashSet<string>(languages, StringComparer.InvariantCultureIgnoreCase);
+
+        // Check if the language groups match the specified *all* languages.
+        foreach (var sitemapLanguageGroup in languageGroups)
+        {
+            var unknownLanguages = sitemapLanguageGroup.Languages
+                .Where(lang => !siteLanguages.Contains(lang))
+                .ToArray();
+
+            if (unknownLanguages.Length > 0)
+            {
+                var groupName = sitemapLanguageGroup.Key.Value;
+                throw new Exception(
+                    $"Language group '{groupName}' contains languages not configured for site: {string.Join(", ", unknownLanguages)}.");
+            }
+        }
+
+        // Ensure each language is present in exactly one language group.
+        var languageMembershipCounts = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
+
+        foreach (var group in languageGroups)
+        {
+            foreach (var lang in group.Languages)
+            {
+                if (!siteLanguages.Contains(lang))
+                {
+                    // Already validated above, but keep defensive guard for future changes.
+                    continue;
+                }
+
+                if (languageMembershipCounts.TryGetValue(lang, out var count))
+                {
+                    languageMembershipCounts[lang] = count + 1;
+                }
+                else
+                {
+                    languageMembershipCounts[lang] = 1;
+                }
+            }
+        }
+
+        // Check for missing or duplicate assignments.
+        var missingLanguages = siteLanguages
+            .Where(lang => !languageMembershipCounts.TryGetValue(lang, out var count) || count == 0)
+            .ToArray();
+
+        if (missingLanguages.Length > 0)
+        {
+            throw new Exception($"Languages not present in any language group: {string.Join(", ", missingLanguages)}.");
+        }
+
+        var duplicateLanguages = languageMembershipCounts
+            .Where(kvp => kvp.Value > 1)
+            .Select(kvp => kvp.Key)
+            .ToArray();
+
+        if (duplicateLanguages.Length > 0)
+        {
+            throw new Exception($"Languages present in multiple language groups: {string.Join(", ", duplicateLanguages)}.");
+        }
+
+        return languageGroups;
     }
 }

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/DefaultSiteCatalogBuilder.cs
@@ -7,6 +7,7 @@ using EPiServer;
 using EPiServer.Core;
 using EPiServer.Core.Routing.Internal;
 using EPiServer.Web;
+using EPiServer.Web.Mvc.Html.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Delaware.Optimizely.Sitemap.Core.Builders;
@@ -102,7 +103,7 @@ public class DefaultSiteCatalogBuilder(
     {
         return
             WithPageFilter((x, _) => x.Content is not IExcludeFromSitemap)
-                .WithPageFilter((x, _) => x.Content is PageData)
+                .WithPageFilter((x, _) => x.Content is PageData { LinkType: PageShortcutType.Normal })
                 .WithPageFilter(new HasAccessSiteCatalogFilter())
                 .WithBlockFilter((x, _) => x.Content is not MediaData);
     }

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/ISiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/ISiteCatalogBuilder.cs
@@ -69,5 +69,15 @@ public interface ISiteCatalogBuilder
     /// </summary>
     ISiteCatalogBuilder WithPageProvider(ISiteCatalogPageProvider pageProvider);
 
+    /// <summary>
+    /// Create split sitemaps by creating <see cref="SitemapLanguageGroup"/> objects with this method.
+    /// </summary>
+    /// <remarks>
+    /// Use this approach to have split sitemaps when having multiple hostnames/languages for a single site.
+    /// When no languages are specified, a 'default' group will be created for the <see cref="ISiteCatalog"/> using the languages specified when adding the sitemap catalog.
+    /// </remarks>
+    /// <param name="languages">The languages to group.</param>
+    /// <param name="name">Unique name for this group.</param>
+    /// <returns></returns>
     ISiteCatalogBuilder WithLanguageGroup(IReadOnlyCollection<string> languages, string name);
 }

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/ISiteCatalogBuilder.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/ISiteCatalogBuilder.cs
@@ -68,4 +68,6 @@ public interface ISiteCatalogBuilder
     /// Registers a custom <see cref="ISiteCatalogPageProvider"/> implementation instead of the default <see cref="DefaultSiteCatalogPageProvider"/>.
     /// </summary>
     ISiteCatalogBuilder WithPageProvider(ISiteCatalogPageProvider pageProvider);
+
+    ISiteCatalogBuilder WithLanguageGroup(IReadOnlyCollection<string> languages, string name);
 }

--- a/src/Delaware.Optimizely.Sitemap.Core/Builders/SiteCatalogDirectory.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Builders/SiteCatalogDirectory.cs
@@ -22,16 +22,15 @@ public class SiteCatalogDirectory(IServiceProvider serviceProvider)
     ///  Add a site catalog to publish to sitemap processing.
     /// </summary>
     /// <returns></returns>
-    public SiteCatalogDirectory AddSiteCatalog(
-        SiteDefinition siteDefinition,
-        Action<ISiteCatalogBuilder>? configure = null)
+    public SiteCatalogDirectory AddSiteCatalog(SiteDefinition siteDefinition,
+        Action<ISiteCatalogBuilder>? configure = null, string[]? languages = null)
     {
         if (siteDefinition == null)
         {
             throw new ArgumentNullException(nameof(siteDefinition), "Site definition cannot be null.");
         }
 
-        var siteCatalog = new DefaultSiteCatalogBuilder(serviceProvider, siteDefinition);
+        var siteCatalog = new DefaultSiteCatalogBuilder(serviceProvider, siteDefinition, languages);
         configure?.Invoke(siteCatalog);
 
         var catalog = siteCatalog.Build();

--- a/src/Delaware.Optimizely.Sitemap.Core/Jobs/FullSiteCatalogJob.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Jobs/FullSiteCatalogJob.cs
@@ -103,6 +103,8 @@ public class FullSiteCatalogJob : ScheduledJobBase
 
             SiteCatalogEventHandler.PublishSiteCatalog(siteCatalog);
 
+            // Might make it configurable to await this or not.
+            // Could be useful when debugging and/or long-running post-publish tasks, if they depend on async too much.
             OnSiteCatalogPublishedAsync(siteCatalog);
         }
 

--- a/src/Delaware.Optimizely.Sitemap.Core/Publishing/ISiteCatalog.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Publishing/ISiteCatalog.cs
@@ -1,4 +1,5 @@
-﻿using EPiServer.Core;
+﻿using Delaware.Optimizely.Sitemap.Shared.Models;
+using EPiServer.Core;
 using EPiServer.Web;
 
 namespace Delaware.Optimizely.Sitemap.Core.Publishing;
@@ -9,7 +10,7 @@ public interface ISiteCatalog
 
     SiteDefinition SiteDefinition { get; }
 
-    public IDictionary<string, IReadOnlyCollection<string>> LanguageGroups { get; set; }
+    IReadOnlyCollection<SitemapLanguageGroup> LanguageGroups { get; }
 
     Task<SiteCatalogEntriesResult> GetPageEntries(IOperationContext context, ContentReference rootPage, string? continuationToken = null);
     
@@ -18,4 +19,12 @@ public interface ISiteCatalog
     Task<SiteCatalogEntriesResult> GetEntries(IOperationContext context, params IContent[] contentItems);
 
     IList<int> GetBlockRoots();
+
+    /// <summary>
+    /// Tries to get the matching <see cref="SitemapLanguageGroup"/> for a given <see cref="SitemapLanguageGroupKey"/>.
+    /// </summary>
+    /// <param name="key">The language group key.</param>
+    /// <param name="languageGroup">The matching language group.</param>
+    /// <returns>True if found.</returns>
+    bool TryGetLanguageGroup(SitemapLanguageGroupKey key, out SitemapLanguageGroup? languageGroup);
 }

--- a/src/Delaware.Optimizely.Sitemap.Core/Publishing/ISiteCatalog.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Publishing/ISiteCatalog.cs
@@ -8,7 +8,9 @@ public interface ISiteCatalog
     string SiteId { get; }
 
     SiteDefinition SiteDefinition { get; }
-    
+
+    public IDictionary<string, IReadOnlyCollection<string>> LanguageGroups { get; set; }
+
     Task<SiteCatalogEntriesResult> GetPageEntries(IOperationContext context, ContentReference rootPage, string? continuationToken = null);
     
     Task<SiteCatalogEntriesResult> GetBlockEntries(IOperationContext context, string? next = null);

--- a/src/Delaware.Optimizely.Sitemap.Core/Publishing/SiteCatalog.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Publishing/SiteCatalog.cs
@@ -1,6 +1,7 @@
 ﻿using Delaware.Optimizely.Sitemap.Core.Client;
 using Delaware.Optimizely.Sitemap.Core.Publishing.ContentProviders;
 using Delaware.Optimizely.Sitemap.Core.Publishing.Mappers;
+using Delaware.Optimizely.Sitemap.Shared.Models;
 using Delaware.Optimizely.Sitemap.Shared.Utilities;
 using EPiServer.Core;
 using EPiServer.Web;
@@ -20,8 +21,7 @@ public class SiteCatalog(
 
     public SiteDefinition SiteDefinition { get; } = siteDefinition;
 
-    public IDictionary<string, IReadOnlyCollection<string>> LanguageGroups { get; set; } =
-        new Dictionary<string, IReadOnlyCollection<string>>();
+    public IReadOnlyCollection<SitemapLanguageGroup> LanguageGroups { get; set; } = new List<SitemapLanguageGroup>();
 
     public virtual async Task<SiteCatalogEntriesResult> GetPageEntries(
         IOperationContext context,
@@ -54,6 +54,13 @@ public class SiteCatalog(
         }
 
         return result.Distinct().ToList();
+    }
+
+    public bool TryGetLanguageGroup(SitemapLanguageGroupKey key, out SitemapLanguageGroup? languageGroup)
+    {
+        languageGroup = LanguageGroups.FirstOrDefault(x => x.Key == key);
+
+        return languageGroup != null;
     }
 
     public virtual async Task<SiteCatalogEntriesResult> GetBlockEntries(IOperationContext context, string? next = null)

--- a/src/Delaware.Optimizely.Sitemap.Core/Publishing/SiteCatalog.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/Publishing/SiteCatalog.cs
@@ -20,6 +20,9 @@ public class SiteCatalog(
 
     public SiteDefinition SiteDefinition { get; } = siteDefinition;
 
+    public IDictionary<string, IReadOnlyCollection<string>> LanguageGroups { get; set; } =
+        new Dictionary<string, IReadOnlyCollection<string>>();
+
     public virtual async Task<SiteCatalogEntriesResult> GetPageEntries(
         IOperationContext context,
         ContentReference rootPage,

--- a/src/Delaware.Optimizely.Sitemap.Core/SourceSet.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/SourceSet.cs
@@ -1,3 +1,6 @@
 ﻿namespace Delaware.Optimizely.Sitemap.Core;
 
-public record SourceSet(IReadOnlyCollection<ISiteResource> Resources, Source Source);
+public record SourceSet(
+    IReadOnlyCollection<ISiteResource> Resources,
+    Source Source,
+    KeyValuePair<string, IReadOnlyCollection<string>> LanguageGroup);

--- a/src/Delaware.Optimizely.Sitemap.Core/SourceSet.cs
+++ b/src/Delaware.Optimizely.Sitemap.Core/SourceSet.cs
@@ -1,6 +1,8 @@
-﻿namespace Delaware.Optimizely.Sitemap.Core;
+﻿using Delaware.Optimizely.Sitemap.Shared.Models;
+
+namespace Delaware.Optimizely.Sitemap.Core;
 
 public record SourceSet(
     IReadOnlyCollection<ISiteResource> Resources,
     Source Source,
-    KeyValuePair<string, IReadOnlyCollection<string>> LanguageGroup);
+    SitemapLanguageGroup LanguageGroup);

--- a/src/Delaware.Optimizely.Sitemap.Shared/Models/SitemapLanguageGroup.cs
+++ b/src/Delaware.Optimizely.Sitemap.Shared/Models/SitemapLanguageGroup.cs
@@ -1,0 +1,23 @@
+﻿using static System.String;
+
+namespace Delaware.Optimizely.Sitemap.Shared.Models;
+
+/// <summary>
+/// Represents a group of languages for sitemap generation.
+/// </summary>
+/// <param name="Key">Unique name for the group.></param>
+/// <param name="Languages">The languages for the group.</param>
+public record SitemapLanguageGroup(SitemapLanguageGroupKey Key, IReadOnlyCollection<string> Languages);
+
+/// <summary>
+/// Represents a key for a <see cref="SitemapLanguageGroup"/>.
+/// </summary>
+/// <param name="Value"></param>
+public record SitemapLanguageGroupKey(string Value)
+{
+    public static implicit operator string(SitemapLanguageGroupKey key) => key.Value;
+
+    public static implicit operator SitemapLanguageGroupKey(string? value) => new(value ?? Empty);
+
+    public override string ToString() => Value;
+}

--- a/src/Delaware.Optimizely.Sitemap.Shared/Models/SitemapState.cs
+++ b/src/Delaware.Optimizely.Sitemap.Shared/Models/SitemapState.cs
@@ -7,31 +7,72 @@ namespace Delaware.Optimizely.Sitemap.Shared.Models;
 [EPiServerDataStore(AutomaticallyCreateStore = false, AutomaticallyRemapStore = true)]
 public class SitemapState : IDynamicData
 {
-    [EPiServerIgnoreDataMember]
-    public IDictionary<int, string> FullPages { get; set; } = new Dictionary<int, string>();   
-    
-    [EPiServerIgnoreDataMember]
+    #region Deprecated
+
+    [EPiServerIgnoreDataMember, Obsolete($"Deprecated in favor of {nameof(FullPagesPerLanguageGroup)}", false)]
+    public IDictionary<int, string> FullPages { get; set; } = new Dictionary<int, string>();
+
+    [EPiServerIgnoreDataMember, Obsolete($"Deprecated in favor of {nameof(DeltaPagesPerLanguageGroup)}", false)]
     public IDictionary<int, string> DeltaPages { get; set; } = new Dictionary<int, string>();
 
     /// <summary>
     /// JSON representation of the <see cref="FullPages"/> property, to avoid having the DDS store this over multiple rows.
     /// </summary>
+    [Obsolete($"Deprecated in favor of {nameof(FullPagesPerLanguageGroupJson)}", false)]
     public string FullPagesJson
     {
         get => JsonSerializer.Serialize(FullPages);
         set => FullPages = (!string.IsNullOrEmpty(value)
             ? JsonSerializer.Deserialize<Dictionary<int, string>>(value)!
-            : new Dictionary<int, string>()) ;
+            : new Dictionary<int, string>());
     }
+
     /// <summary>
     /// JSON representation of the <see cref="DeltaPages"/> property, to avoid having the DDS store this over multiple rows.
     /// </summary>
+    [Obsolete($"Deprecated in favor of {nameof(DeltaPagesPerLanguageGroupJson)}", false)]
     public string DeltaPagesJson
     {
         get => JsonSerializer.Serialize(DeltaPages);
         set => DeltaPages = (!string.IsNullOrEmpty(value)
             ? JsonSerializer.Deserialize<Dictionary<int, string>>(value)!
-            : new Dictionary<int, string>()) ;
+            : new Dictionary<int, string>());
+    }
+
+    #endregion Deprecated
+
+    /// <summary>
+    /// Maps language group keys to sitemap page indexes and their corresponding URLs.
+    /// </summary>
+    [EPiServerIgnoreDataMember]
+    public IDictionary<string, IDictionary<int, string>> FullPagesPerLanguageGroup { get; set; } = new Dictionary<string, IDictionary<int, string>>();
+
+    /// <summary>
+    /// Maps language group keys to delta sitemap page indexes and their corresponding URLs.
+    /// </summary>
+    [EPiServerIgnoreDataMember]
+    public IDictionary<string, IDictionary<int, string>> DeltaPagesPerLanguageGroup { get; set; } = new Dictionary<string, IDictionary<int, string>>();
+
+    /// <summary>
+    /// JSON representation of the <see cref="FullPagesPerLanguageGroup"/> property, to avoid having the DDS store this over multiple rows.
+    /// </summary>
+    public string FullPagesPerLanguageGroupJson
+    {
+        get => JsonSerializer.Serialize(FullPagesPerLanguageGroup);
+        set => FullPagesPerLanguageGroup = !string.IsNullOrEmpty(value)
+            ? JsonSerializer.Deserialize<Dictionary<string, IDictionary<int, string>>>(value)!
+            : new Dictionary<string, IDictionary<int, string>>();
+    }
+
+    /// <summary>
+    /// JSON representation of the <see cref="DeltaPagesPerLanguageGroup"/> property, to avoid having the DDS store this over multiple rows.
+    /// </summary>
+    public string DeltaPagesPerLanguageGroupJson
+    {
+        get => JsonSerializer.Serialize(DeltaPagesPerLanguageGroup);
+        set => DeltaPagesPerLanguageGroup = !string.IsNullOrEmpty(value)
+            ? JsonSerializer.Deserialize<Dictionary<string, IDictionary<int, string>>>(value)!
+            : new Dictionary<string, IDictionary<int, string>>();
     }
 
     public Identity Id { get; set; } = null!;

--- a/src/Delaware.Optimizely.Sitemap/BuilderExtensions.cs
+++ b/src/Delaware.Optimizely.Sitemap/BuilderExtensions.cs
@@ -101,7 +101,7 @@ public static class BuilderExtensions
     /// which calls <see cref="Sitemap.BuilderExtensions.AddSitemapCatalog"/> and <see cref="WithEmbeddedSitemap"/> internally.
     /// </summary>
     /// <param name="siteDefinition">The site definition to create a catalog for.</param>
-    /// <param name="languages">The site's languages the sitemap needs to be published and served in.</param>
+    /// <param name="languages">*All* site's languages the sitemap needs to be published and served in.</param>
     public static IServiceProvider AddEmbeddedSitemapCatalog(
         this IServiceProvider serviceProvider,
         SiteDefinition siteDefinition,

--- a/src/Delaware.Optimizely.Sitemap/DefaultSitemapProcessor.cs
+++ b/src/Delaware.Optimizely.Sitemap/DefaultSitemapProcessor.cs
@@ -47,7 +47,7 @@ public class DefaultSitemapProcessor : ISiteResourceProcessor
 
         foreach (var sitemapDataExtractor in Extractors)
         {
-            var urls = await sitemapDataExtractor.Extract(sourceSet.Resources);
+            var urls = await sitemapDataExtractor.Extract(sourceSet);
 
             foreach (var url in urls)
             {

--- a/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
+++ b/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
@@ -211,7 +211,7 @@ public class EmbeddedSitemapMiddleware(
         httpContext.Response.Headers["Expires"] = "0";
     }
 
-    private string DetermineLanguageGroupKey(HttpContext httpContext)
+    private SitemapLanguageGroupKey DetermineLanguageGroupKey(HttpContext httpContext)
     {
         var currentCi = DetermineCurrentCultureInfo(httpContext);
 
@@ -221,9 +221,12 @@ public class EmbeddedSitemapMiddleware(
                 siteCatalog
                     .LanguageGroups
                     .EmptyWhenNull()
-                    .FirstOrDefault(lg => lg.Value.Contains(currentCi.Name, StringComparer.InvariantCultureIgnoreCase));
+                    .FirstOrDefault(lg => lg.Languages.Contains(currentCi.Name, StringComparer.InvariantCultureIgnoreCase));
 
-            return matchingLanguageGroup.Key;
+            if (matchingLanguageGroup != null)
+            {
+                return matchingLanguageGroup.Key;
+            }
         }
 
         return DefaultSiteCatalogBuilder.DefaultLanguageGroupName; // TODO shared constant?
@@ -231,7 +234,7 @@ public class EmbeddedSitemapMiddleware(
 
     private static IEnumerable<SitemapUrl> GenerateSitemapUrls(
         Uri baseUrl,
-        string languageGroupKey,
+        SitemapLanguageGroupKey languageGroupKey,
         SitemapState? state)
     {
         if (state == null || !state.FullPagesPerLanguageGroup.TryGetValue(languageGroupKey, out var fullPages))

--- a/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
+++ b/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
@@ -37,7 +37,7 @@ public class EmbeddedSitemapMiddleware(
             // Serve sitemap index.
             await WriteSitemapIndexAsync(context, state);
 
-            context.Request.ContentType = "text/xml";
+            context.Request.ContentType = "application/xml";
 
             return;
         }

--- a/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
+++ b/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
@@ -37,8 +37,6 @@ public class EmbeddedSitemapMiddleware(
             // Serve sitemap index.
             await WriteSitemapIndexAsync(context, state);
 
-            context.Request.ContentType = "application/xml";
-
             return;
         }
 
@@ -196,6 +194,8 @@ public class EmbeddedSitemapMiddleware(
 
         // Ensure no caching.
         EnsureNoCaching(context);
+
+        context.Response.ContentType = "application/xml";
 
         await context.Response.WriteAsync(result);
 

--- a/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
+++ b/src/Delaware.Optimizely.Sitemap/Middleware/EmbeddedSitemapMiddleware.cs
@@ -166,6 +166,7 @@ public class EmbeddedSitemapMiddleware(
 
     private async Task<bool> WriteSitemapIndexAsync(HttpContext context, SitemapState state)
     {
+        // Are there any sitemap entries?
         var totalEntryCount = embeddedSiteCatalogClient.GetCatalogEntryCount(SiteDefinition.Current.Name);
 
         if (totalEntryCount <= 0)
@@ -175,7 +176,10 @@ public class EmbeddedSitemapMiddleware(
 
         var languageGroupKey = DetermineLanguageGroupKey(context);
 
-        var sitemapUrls = GenerateSitemapUrls(SiteDefinition.Current.SiteUrl, languageGroupKey, state);
+        // Get URI from context.
+        var baseUri = GetBaseUri(context);
+
+        var sitemapUrls = GenerateSitemapUrls(baseUri, languageGroupKey, state);
         var index = new SitemapIndex(sitemapUrls.ToList());
 
         using var memory = new MemoryStream();
@@ -183,7 +187,8 @@ public class EmbeddedSitemapMiddleware(
         // Write the XML.
         await sitemapXmlWriter.WriteSitemapIndex(index, memory);
 
-        memory.Seek(0, SeekOrigin.Begin); // Reset the stream position.
+        // Reset the stream position.
+        memory.Seek(0, SeekOrigin.Begin); 
 
         // Convert stream to string.
         using var reader = new StreamReader(memory);
@@ -202,6 +207,20 @@ public class EmbeddedSitemapMiddleware(
         var contentLanguageAccessor = fromHttpContext.RequestServices.GetService<IContentLanguageAccessor>();
 
         return contentLanguageAccessor!.Language;
+    }
+
+    private static Uri GetBaseUri(HttpContext context)
+    {
+        var request = context.Request;
+        var builder = new UriBuilder
+        {
+            Scheme = request.Scheme,
+            Host = request.Host.Host,
+            Port = request.Host.Port ?? (request.Scheme == "https" ? 443 : 80),
+            Path = request.PathBase.ToString()
+        };
+
+        return builder.Uri;
     }
 
     private static void EnsureNoCaching(HttpContext httpContext)

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/ConfiguredSitemapDataExtractor.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/ConfiguredSitemapDataExtractor.cs
@@ -46,8 +46,7 @@ public class ConfiguredSitemapDataExtractor : ISitemapDataExtractor
     protected virtual async Task<SiteResourceUrls?> Extract(
         ISiteResource resource, 
         SitemapDataExtractorConfig config,
-        KeyValuePair<string, 
-            IReadOnlyCollection<string>> sourceSetLanguageGroup)
+        SitemapLanguageGroup sourceSetLanguageGroup)
     {
         var urls = new List<Url>();
 
@@ -61,7 +60,7 @@ public class ConfiguredSitemapDataExtractor : ISitemapDataExtractor
         await foreach (var multiplication in config.Multiplier.Multiply(resource))
         {
             // Default language is the first of the languages specified in the group - if any.
-            defaultLanguage ??= sourceSetLanguageGroup.Value?.FirstOrDefault();
+            defaultLanguage ??= sourceSetLanguageGroup.Languages.FirstOrDefault();
 
             // Still no default language? Allow multiplier to configure the default language.
             defaultLanguage ??= multiplication.Variables.GetValueOrDefault(SharedSitemapConstants.DefaultLanguageVariable, null) as string;

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/DefaultSiteMapXmlService.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/DefaultSiteMapXmlService.cs
@@ -117,8 +117,9 @@ internal class DefaultSitemapGeneratorService(
         }
     }
 
-    private async Task<IReadOnlyCollection<string>?> DoGenerateAndPersistAsync(ISiteCatalog catalog,
-        KeyValuePair<string, IReadOnlyCollection<string>> languageGroup,
+    private async Task<IReadOnlyCollection<string>?> DoGenerateAndPersistAsync(
+        ISiteCatalog catalog,
+        SitemapLanguageGroup languageGroup,
         IReadOnlyCollection<SiteCatalogEntry> entries,
         StoredPageCount storedPageCount,
         bool isDelta)

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/DynamicContent/DynamicContentSitemapExtractor.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/DynamicContent/DynamicContentSitemapExtractor.cs
@@ -15,9 +15,11 @@ public class DynamicContentSitemapExtractor(IList<IDynamicContentRootProcessor> 
 
     #region ISitemapDataExtractor
 
-    public async Task<IReadOnlyList<SiteResourceUrls>> Extract(IReadOnlyCollection<ISiteResource> resources)
+    public async Task<IReadOnlyList<SiteResourceUrls>> Extract(SourceSet sourceSet)
     {
-        if (resources is null) throw new ArgumentNullException(nameof(resources));
+        if (sourceSet == null) throw new ArgumentNullException(nameof(sourceSet));
+        
+        var resources = sourceSet.Resources;
 
         var results = new List<SiteResourceUrls>();
 

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/ISitemapDataExtractor.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/ISitemapDataExtractor.cs
@@ -4,5 +4,5 @@ namespace Delaware.Optimizely.Sitemap.SitemapXml;
 
 public interface ISitemapDataExtractor
 {
-    Task<IReadOnlyList<SiteResourceUrls>> Extract(IReadOnlyCollection<ISiteResource> resources);
+    Task<IReadOnlyList<SiteResourceUrls>> Extract(SourceSet sourceSet);
 }

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/DefaultSitemapXmlStorageProvider.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/DefaultSitemapXmlStorageProvider.cs
@@ -30,7 +30,7 @@ public class DefaultSitemapXmlStorageProvider(
 
     public string Store(
         SiteDefinition siteDefinition,
-        KeyValuePair<string, IReadOnlyCollection<string>> languageGroup,
+        SitemapLanguageGroup languageGroup,
         Stream inputStream, 
         int pageNumber,
         bool isDelta)
@@ -72,7 +72,7 @@ public class DefaultSitemapXmlStorageProvider(
 
     private void EnsureInitialized(
         SiteDefinition siteDefinition,
-        KeyValuePair<string, IReadOnlyCollection<string>> languageGroup,
+        SitemapLanguageGroup languageGroup,
         out ContentReference mostSpecificFolder)
     {
         var loaderOptions = LanguageSelector.MasterLanguage();

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/DefaultSitemapXmlStorageProvider.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/DefaultSitemapXmlStorageProvider.cs
@@ -64,10 +64,8 @@ public class DefaultSitemapXmlStorageProvider(
 
         contentRepository.Save(file, SaveAction.Publish, AccessLevel.NoAccess);
 
-        var urlResolverArgs = new UrlResolverArguments { ForceAbsolute = true };
-
         return urlResolver
-            .GetUrl(file.ContentLink, null, urlResolverArgs);
+            .GetUrl(file.ContentLink, null);
     }
 
     private void EnsureInitialized(

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/ISitemapXmlStorageProvider.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/ISitemapXmlStorageProvider.cs
@@ -5,7 +5,6 @@ namespace Delaware.Optimizely.Sitemap.SitemapXml.Storage;
 
 public interface ISitemapXmlStorageProvider
 {
-    public string Store(SiteDefinition siteDefinition, Stream inputStream, int pageNumber, bool isDelta);
-
-    public void Clean(SiteDefinition siteDefinition, SitemapState forState);
+    public string Store(SiteDefinition siteDefinition, KeyValuePair<string, IReadOnlyCollection<string>> languageGroup,
+        Stream inputStream, int pageNumber, bool isDelta);
 }

--- a/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/ISitemapXmlStorageProvider.cs
+++ b/src/Delaware.Optimizely.Sitemap/SitemapXml/Storage/ISitemapXmlStorageProvider.cs
@@ -5,6 +5,6 @@ namespace Delaware.Optimizely.Sitemap.SitemapXml.Storage;
 
 public interface ISitemapXmlStorageProvider
 {
-    public string Store(SiteDefinition siteDefinition, KeyValuePair<string, IReadOnlyCollection<string>> languageGroup,
+    public string Store(SiteDefinition siteDefinition, SitemapLanguageGroup languageGroup,
         Stream inputStream, int pageNumber, bool isDelta);
 }


### PR DESCRIPTION
# Introduction

Introduced multi-sitemap for sites by configuring language groups.

Use case: mult-host/language setups requiring split sitemaps.

The stored state, f.e.:

`{
    "CorpModule-Netherlands": {
        "0": "/globalassets/sitemaps/spir-corp/Corp-netherlands/0/?v=4ae42b"
    },
    "CorpModule-France": {
        "0": "/globalassets/sitemaps/spir-corp/Corp-france/0/?v=4ae637"
    }
}`

# Changes

## SitemapLanguageGroup model

`SitemapLanguageGroup` combines a unique name and a list of languages into a single object.

##  ISiteCatalogBuilder WithLanguageGroup() method

Created (optional) builder method to configure `SitemapLanguageGroup`s:

`ISiteCatalogBuilder WithLanguageGroup(IReadOnlyCollection<string> languages, string name);`

When a `ISiteCatalog` contains no `SitemapLanguageGroup` configuration, a _Default_ group is created containing *all* languages given to the builder.

Otherwise, logic checks if the *all* languages is fully and correctly mapped to different group objects, otherwise an exception is thrown.

## SitemapState

`SitemapState `now stores the sitemap pages per `SitemapLanguageGroup`. Old setup has been marked as deprecated.

## Processing

Processing the  `ISiteCatalog` now takes these new groupings into account by iterating the groups during processing.

## Serving

As a multi-host/multi-language setup steers the language resolving, now looking at the request to determine the current matching language group to serve the sitemap data for.

# Various

Minor updates:

* Fixed mimetype for sitemap.xml index file.
* Fixed indexing of pages with shortcuts configured.